### PR TITLE
Add support for checking substitute consecutive-gap rest moments + spinner/slider support

### DIFF
--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -112,9 +112,9 @@ namespace MVTaikoChecks.Checks.Compose
             var continuousMappingMinorLimit = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_KANTAN, 36},
-                { DIFF_FUTSUU, 20},
-                { DIFF_MUZU, 32},
-                { DIFF_ONI, 32}
+                { DIFF_FUTSUU, 36},
+                { DIFF_MUZU, 20},
+                { DIFF_ONI, 20}
             };
 
             // for each diff: string to output describing continuous mapping limitations (warning severity)

--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -108,7 +108,7 @@ namespace MVTaikoChecks.Checks.Compose
                 { DIFF_ONI, "1/1"}
             };
 
-            // for each diff: string to output describing rest moment requirements
+            // for each diff: string to output describing continuous mapping limitations (minor issue severity)
             var continuousMappingMinorLimit = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_KANTAN, 36},
@@ -117,7 +117,7 @@ namespace MVTaikoChecks.Checks.Compose
                 { DIFF_ONI, 32}
             };
 
-            // for each diff: string to output describing rest moment requirements
+            // for each diff: string to output describing continuous mapping limitations (warning severity)
             var continuousMappingWarningLimit = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_KANTAN, 44},
@@ -161,7 +161,7 @@ namespace MVTaikoChecks.Checks.Compose
                             smallestConsecutiveGapMs = Math.Min(smallestConsecutiveGapMs, gap);
                         }
 
-                        // check if the backward-looking current string of notes is a rest moment (end of continuous mapping)
+                        // check if the backward-looking current string of notes is a rest moment
                         if (smallestConsecutiveGapMs + MS_EPSILON >= minimalRestMomentGapMs)
                         {
                             isBeginningOfContinuousMapping = true;
@@ -184,20 +184,20 @@ namespace MVTaikoChecks.Checks.Compose
                             smallestConsecutiveGapMs = Math.Min(smallestConsecutiveGapMs, gap);
                         }
 
-                        // check if the forward-looking current string of notes is a rest moment (end of continuous mapping)
+                        // check if the forward-looking current string of notes is a rest moment
                         if (smallestConsecutiveGapMs + MS_EPSILON >= minimalRestMomentGapMs)
                         {
                             isEndOfContinuousMapping = true;
                         }
                     }
 
-                    // check if this is the first note of a continuously mapped section
+                    // check if this is the first note of a continuously mapped section, if so record the timestamp for later once we find the end
                     if (isBeginningOfContinuousMapping)
                     {
                         currentContinuousSectionStartTimeMs = current.time;
                     }
 
-                    // check if this is the last note of a continuously mapped section
+                    // check if this is the last note of a continuously mapped section, if so check if it's too long
                     if (isEndOfContinuousMapping)
                     {
                         var continuouslyMappedDurationMs = current.GetEndTime() - currentContinuousSectionStartTimeMs;

--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -129,7 +129,6 @@ namespace MVTaikoChecks.Checks.Compose
             foreach (var diff in _DIFFICULTIES)
             {
                 var currentContinuousSectionStartTimeMs = objects.FirstOrDefault()?.time ?? 0;
-                var wasLastObjectRestMoment = true;
                 for (int i = 0; i < objects.Count; i++)
                 {
                     var current = objects.SafeGetIndex(i);
@@ -238,8 +237,6 @@ namespace MVTaikoChecks.Checks.Compose
                             ).ForDifficulties(diff);
                         }
                     }
-
-                    wasLastObjectRestMoment = isBeginningOfContinuousMapping || isEndOfContinuousMapping;
                 }
             }
         }

--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -129,6 +129,7 @@ namespace MVTaikoChecks.Checks.Compose
             foreach (var diff in _DIFFICULTIES)
             {
                 var currentContinuousSectionStartTimeMs = objects.FirstOrDefault()?.time ?? 0;
+                var isWithinContinuousMapping = false;
                 for (int i = 0; i < objects.Count; i++)
                 {
                     var current = objects.SafeGetIndex(i);
@@ -193,12 +194,14 @@ namespace MVTaikoChecks.Checks.Compose
                     // check if this is the first note of a continuously mapped section, if so record the timestamp for later once we find the end
                     if (isBeginningOfContinuousMapping)
                     {
+                        isWithinContinuousMapping = true;
                         currentContinuousSectionStartTimeMs = current.time;
                     }
 
                     // check if this is the last note of a continuously mapped section, if so check if it's too long
-                    if (isEndOfContinuousMapping)
+                    if (isEndOfContinuousMapping && isWithinContinuousMapping)
                     {
+                        isWithinContinuousMapping = false;
                         var continuouslyMappedDurationMs = current.GetEndTime() - currentContinuousSectionStartTimeMs;
 
                         double beatsWithoutBreaks = Math.Floor((continuouslyMappedDurationMs + MS_EPSILON) / normalizedMsPerBeat);

--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -104,7 +104,7 @@ namespace MVTaikoChecks.Checks.Compose
             {
                 { DIFF_KANTAN, "3/1"},
                 { DIFF_FUTSUU, "2/1"},
-                { DIFF_MUZU, "3/2 or three consecutive 1/1"},
+                { DIFF_MUZU, "3/2 or 3 x 1/1"},
                 { DIFF_ONI, "1/1"}
             };
 


### PR DESCRIPTION
## Summary
In the osu!taiko ranking criteria, the [Muzukashii guidelines](https://osu.ppy.sh/wiki/en/Ranking_criteria/osu%21taiko#muzukashii) specify an alternative substitute for rest moments, which involve using several consecutive smaller rest moments in place of a larger singular rest moment:
> Using at least 3 consecutive rest moments that are 1/1 is an acceptable substitute if either the pace of the music makes rest moments counter-intuitive or if the continuously mapped part is overall more forgiving to the player.

The current Taiko mapset verifier plugin does not check for this, and only supports the larger singular 3/2 rest moment.

This pull request adds support for the substitute. It also considers 3 consecutive rest moments that are all larger than 1/1 but smaller than 3/2 also acceptable. The updated logic also now considers spinner and slider duration as continuous mapping.

This includes a pretty large refactor for the `RestMomentCheck.cs` class overall to make this happen.

Other consecutive substitutes can also easily be added with these changes.

## Approach
The previous logic looked at all hit objects in a map and took each adjacent pair, calculated the gap between them, and used that to determine if an object was a "rest moment" or not.

The new logic has several significant logical changes to make the substitute checking work:
* Not only does it looks at 2 adjacent objects at a time, but will look at more, up to the number of consecutive instances needed (so for the Muzukashii, it will look at strings of 3 adjacent objects).
* This new logic also looks both forward and backward, instead of forward-only. This allows us to not only determine if the object is attached to a "rest moment", but also can tell if it's the beginning, end, or middle of a continuously mapped section, which is necessary for this support
* The new logic uses `HitObject.GetEndTime()` when calculating the gaps between objects. This in turn also adds support for recognizing spinners and sliders as continuous mapping (instead of only taking into consideration the heads of these objects)

## Known issues
* This change does keep [BPM scaling](https://github.com/Hiviexd/MVTaikoChecks#bpm-scaling) by using `OsuUtils.GetNormalizedMsPerBeat()`. However the string used in the recommendation what type of rest moment to use shows values for unscaled BPM.
  * This bug already exists in the current implementation anyway, so this isn't a regression
  * Doesn't seem like a big deal tbh

## Testing
I've tested this new logic, not only for detecting violations of the RC guideline, but by checking the output of all detected continuous mapping (including stuff that obeys the guidelines) in the map according to the update rest moment detection.

If you would like to view this output, enable following debug flag to `true` and recompile/reinstall the DLL:
* Line 27 in this PR diff: `private const bool _DEBUG_SEE_ALL_CONTINUOUS_MAPPING = false;` -> Change to `true`
