### PR TITLE
Add checks for conflicting Kiai or volumes

### DIFF
--- a/Checks/Timing/ConflictingKiaisCheck.cs
+++ b/Checks/Timing/ConflictingKiaisCheck.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+
+using MapsetParser.objects;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using MVTaikoChecks.Utils;
+
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Timing
+{
+    [Check]
+    public class ConflictingKiaisCheck : BeatmapCheck
+    {
+        private const string _WARNING = nameof(_WARNING);
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "Nostril",
+                Category = "Timing",
+                Message = "Conflicting Kiai enablement",
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Ensuring that Kiai enablement does not conflict at a single timestamp."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    In this situation, the green line Kiai overrides red line Kiai. However, this is fragile and may not be the intended behavior."
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new Dictionary<string, IssueTemplate>()
+            {
+                {
+                    _WARNING,
+                    new IssueTemplate(LEVEL_WARNING, "{0} Conflicting Kiais", "timestamp - ").WithCause(
+                        "Conflicting Kiai states are set at the same time. Check the timing panel."
+                    )
+                }
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            // making a hashset for the results to de-dupe any duplicate issues
+            HashSet<double> conflictTimestamps = new HashSet<double>();
+
+            for (int i = 0; i < beatmap.timingLines.Count; i++)
+            {
+                var line = beatmap.timingLines.SafeGetIndex(i);
+                var nextLine = beatmap.timingLines.SafeGetIndex(i + 1);
+
+                // check if this line is concurrent with the next one
+                if (line.offset == nextLine?.offset)
+                {
+                    // check if kiai enablement doesn't match
+                    if (nextLine.kiai != line.kiai)
+                    {
+                        conflictTimestamps.Add(line.offset);
+                    }
+                }
+            }
+
+            foreach (var conflictTimestamp in conflictTimestamps)
+            {
+                yield return new Issue(
+                    GetTemplate(_WARNING),
+                    beatmap,
+                    Timestamp.Get(conflictTimestamp)
+                );
+            }
+        }
+    }
+}

--- a/Checks/Timing/ConflictingVolumesCheck.cs
+++ b/Checks/Timing/ConflictingVolumesCheck.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+
+using MapsetParser.objects;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using MVTaikoChecks.Utils;
+
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Timing
+{
+    [Check]
+    public class ConflictingVolumesCheck : BeatmapCheck
+    {
+        private const string _WARNING = nameof(_WARNING);
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "Nostril",
+                Category = "Timing",
+                Message = "Conflicting hitsound volumes",
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Ensuring that hitsound volumes do not conflict at a single timestamp."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    In this situation, the green line volume overrides red line volume. However, this is fragile and may not be the intended behavior."
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new Dictionary<string, IssueTemplate>()
+            {
+                {
+                    _WARNING,
+                    new IssueTemplate(LEVEL_WARNING, "{0} Conflicting hitsound volumes", "timestamp - ").WithCause(
+                        "Conflicting hitsound volumes are set at the same time. Check the timing panel."
+                    )
+                }
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            // making a hashset for the results to de-dupe any duplicate issues
+            HashSet<double> conflictTimestamps = new HashSet<double>();
+
+            for (int i = 0; i < beatmap.timingLines.Count; i++)
+            {
+                var line = beatmap.timingLines.SafeGetIndex(i);
+                var nextLine = beatmap.timingLines.SafeGetIndex(i + 1);
+
+                // check if this line is concurrent with the next one
+                if (line.offset == nextLine?.offset)
+                {
+                    // check if hitsound volume doesn't match
+                    if (nextLine.volume != line.volume)
+                    {
+                        conflictTimestamps.Add(line.offset);
+                    }
+                }
+            }
+
+            foreach (var conflictTimestamp in conflictTimestamps)
+            {
+                yield return new Issue(
+                    GetTemplate(_WARNING),
+                    beatmap,
+                    Timestamp.Get(conflictTimestamp)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Often when a red line is used in a map, a green line should be placed concurrently to preserve SV. Sometimes this concurrent green line can have conflicting Kiai enablement or hitsound volumes.

The green line takes priority in this case, so this isn't technically unrankable or causing an issue. However it's fragile and can easily break when changes are applied to a map, due to stuff like addressing rounding errors or blunders when offsetting green lines.

Also, even in the case when it's not breaking anything - conflicting Kiais/volumes may still be indicative of the unintended Kiai/volume being applied, so I think it makes sense to warn the mapper in all of these cases.

These checks also technically happen for red/red concurrent lines, and green/green concurrent lines. Base MV already has checks to catch these and warn them as unrankable, but I don't see this hurting either so I left the warnings that these checks produce in as well.

## Approach
Implemented the Kiai/Volume checks as two separate ones, but they're almost identical logically.

General logic is as follows:
1. Iterate through all pairs of "adjacent-by-index" timing lines (both red and green)
2. Determine if the "adjacent-by-index" lines are actually concurrent
3. If concurrent, check if kiais/volumes don't match
4. If they don't match, add it to a hashset to de-dupe (in case there's 3 or more concurrent lines)
5. Emit issues for each element in the hashset

## Known issues
* Seems pretty clean from my testing

## Testing
Tested by inting some maps and checking if it works. Tested with red/green, green/green, red/red. Also tested with 3 or more concurrent lines. All of these cases work fine.
