### PR TITLE
Fix end timestamp for rest moment check

### DIFF
--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -223,7 +223,7 @@ namespace MVTaikoChecks.Checks.Compose
                                 GetTemplate(_WARNING),
                                 beatmap,
                                 Timestamp.Get(currentContinuousSectionStartTimeMs).Trim() + ">",
-                                Timestamp.Get(current.time),
+                                Timestamp.Get(current.GetEndTime()),
                                 breakTypes[diff],
                                 $"{beatsWithoutBreaks}/1"
                             ).ForDifficulties(diff);
@@ -234,7 +234,7 @@ namespace MVTaikoChecks.Checks.Compose
                                 GetTemplate(_MINOR),
                                 beatmap,
                                 Timestamp.Get(currentContinuousSectionStartTimeMs).Trim() + ">",
-                                Timestamp.Get(current.time),
+                                Timestamp.Get(current.GetEndTime()),
                                 breakTypes[diff],
                                 $"{beatsWithoutBreaks}/1"
                             ).ForDifficulties(diff);


### PR DESCRIPTION
Quick fix. The end time is properly used in the check and for calculating the duration of continuous mapping, but for the outputted timestamp itself I forgot to use `GetEndTime()` instead of `time`.

So this makes it so the end time stamp will correctly be at the end of spinners/sliders.