### PR TITLE
Rewrite the UnrankableFinisherCheck and also add a TaikoUtils class

### DIFF
--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -131,17 +131,17 @@ namespace MVTaikoChecks.Checks.Compose
             {
                 foreach (var current in finishers)
                 {
-                    var sameColorBefore = (current.Prev()?.IsDon() ?? null) == current.IsDon();
-                    var sameColorAfter = (current.Next()?.IsDon() ?? null) == current.IsDon();
+                    var sameColorBefore = current.IsMono();
+                    var sameColorAfter = current.Next()?.IsMono() ?? false;
                     var isInPattern = !current.IsNotInPattern();
                     var isFirstNote = current.IsAtBeginningOfPattern();
                     var isFinalNote = current.IsAtEndOfPattern();
 
                     // check for unrankable finishers (problem)
-                    if ((checkAndHandleIssues(diff, maximalGapBeats, beatmap, current) && isInPattern) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore && !isFirstNote) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter && !isFinalNote) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNote, beatmap, current) && !isFinalNote)) {
+                    if ((checkGap(diff, maximalGapBeats, beatmap, current) && isInPattern) ||
+                        (checkGap(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore && !isFirstNote) ||
+                        (checkGap(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter && !isFinalNote) ||
+                        (checkGap(diff, maximalGapBeatsRequiringFinalNote, beatmap, current) && !isFinalNote)) {
                         yield return new Issue(
                             GetTemplate(_PROBLEM),
                             beatmap,
@@ -151,10 +151,10 @@ namespace MVTaikoChecks.Checks.Compose
                     }
 
                     // check for abnormal finishers (warning)
-                    if ((checkAndHandleIssues(diff, maximalGapBeatsWarning, beatmap, current) && isInPattern) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBeforeWarning, beatmap, current) && sameColorBefore && !isFirstNote) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfterWarning, beatmap, current) && sameColorAfter && !isFinalNote) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNoteWarning, beatmap, current) && !isFinalNote)) {
+                    if ((checkGap(diff, maximalGapBeatsWarning, beatmap, current) && isInPattern) ||
+                        (checkGap(diff, maximalGapBeatsRequiringColorChangeBeforeWarning, beatmap, current) && sameColorBefore && !isFirstNote) ||
+                        (checkGap(diff, maximalGapBeatsRequiringColorChangeAfterWarning, beatmap, current) && sameColorAfter && !isFinalNote) ||
+                        (checkGap(diff, maximalGapBeatsRequiringFinalNoteWarning, beatmap, current) && !isFinalNote)) {
                         yield return new Issue(
                             GetTemplate(_WARNING),
                             beatmap,
@@ -167,7 +167,7 @@ namespace MVTaikoChecks.Checks.Compose
             yield break;
         }
 
-        private bool checkAndHandleIssues(
+        private bool checkGap(
             Beatmap.Difficulty diff,
             Dictionary<Beatmap.Difficulty, double> maximalGapBeats,
             Beatmap beatmap,

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -82,17 +82,14 @@ namespace MVTaikoChecks.Checks.Compose
             // any finisher pattern spacing equal to or smaller than this gap is a problem
             var maximalGapBeats = new Dictionary<Beatmap.Difficulty, double>()
             {
-                { DIFF_KANTAN,  1.0/3 },
+                { DIFF_KANTAN,  1.0/2 },
                 { DIFF_FUTSUU,  1.0/3 },
                 { DIFF_MUZU,    1.0/4 },
                 { DIFF_ONI,     1.0/6 }
             };
 
             // any finisher pattern spacing equal to or smaller than this gap is a problem
-            var maximalGapBeatsWarning = new Dictionary<Beatmap.Difficulty, double>()
-            {
-                { DIFF_KANTAN,  1.0/2 }
-            };
+            var maximalGapBeatsWarning = new Dictionary<Beatmap.Difficulty, double>() { };
 
             // any finisher pattern spacing equal to or smaller than this gap without a color change before is a problem
             var maximalGapBeatsRequiringColorChangeBefore = new Dictionary<Beatmap.Difficulty, double>()

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -89,7 +89,10 @@ namespace MVTaikoChecks.Checks.Compose
             };
 
             // any finisher pattern spacing equal to or smaller than this gap is a problem
-            var maximalGapBeatsWarning = new Dictionary<Beatmap.Difficulty, double>() { };
+            var maximalGapBeatsWarning = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_MUZU,    1.0/3 }
+            };
 
             // any finisher pattern spacing equal to or smaller than this gap without a color change before is a problem
             var maximalGapBeatsRequiringColorChangeBefore = new Dictionary<Beatmap.Difficulty, double>()

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -133,11 +133,12 @@ namespace MVTaikoChecks.Checks.Compose
                 {
                     var sameColorBefore = (current.Prev()?.IsDon() ?? null) == current.IsDon();
                     var sameColorAfter = (current.Next()?.IsDon() ?? null) == current.IsDon();
+                    var isInPattern = !current.IsNotInPattern();
                     var isFirstNote = current.IsAtBeginningOfPattern();
                     var isFinalNote = current.IsAtEndOfPattern();
 
                     // check for unrankable finishers (problem)
-                    if ((checkAndHandleIssues(diff, maximalGapBeats, beatmap, current)) ||
+                    if ((checkAndHandleIssues(diff, maximalGapBeats, beatmap, current) && isInPattern) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore && !isFirstNote) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter && !isFinalNote) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNote, beatmap, current) && !isFinalNote)) {
@@ -150,7 +151,7 @@ namespace MVTaikoChecks.Checks.Compose
                     }
 
                     // check for abnormal finishers (warning)
-                    if ((checkAndHandleIssues(diff, maximalGapBeatsWarning, beatmap, current)) ||
+                    if ((checkAndHandleIssues(diff, maximalGapBeatsWarning, beatmap, current) && isInPattern) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBeforeWarning, beatmap, current) && sameColorBefore && !isFirstNote) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfterWarning, beatmap, current) && sameColorAfter && !isFinalNote) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNoteWarning, beatmap, current) && !isFinalNote)) {

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -107,14 +107,14 @@ namespace MVTaikoChecks.Checks.Compose
             var maximalGapBeatsRequiringColorChangeBeforeWarning = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_INNER,   1.0/3 },
-                { DIFF_HELL,   1.0/3 }
+                { DIFF_HELL,    1.0/3 }
             };
 
             // any finisher pattern spacing equal to or smaller than this gap without a color change after is a warning
             var maximalGapBeatsRequiringColorChangeAfterWarning = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_INNER,   1.0/3 },
-                { DIFF_HELL,   1.0/3 }
+                { DIFF_HELL,    1.0/3 }
             };
 
             // any finisher pattern spacing equal to or smaller than this gap while not being at the end of the pattern is a problem
@@ -127,7 +127,7 @@ namespace MVTaikoChecks.Checks.Compose
             var maximalGapBeatsRequiringFinalNoteWarning = new Dictionary<Beatmap.Difficulty, double>()
             {
                 { DIFF_INNER,   1.0/3 },
-                { DIFF_HELL,   1.0/3 }
+                { DIFF_HELL,    1.0/3 }
             };
 
             foreach (var diff in _DIFFICULTIES)

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -34,7 +34,7 @@ namespace MVTaikoChecks.Checks.Compose
         public override CheckMetadata GetMetadata() =>
             new BeatmapCheckMetadata()
             {
-                Author = "Hivie & Nostril",
+                Author = "Hivie, Nostril",
                 Category = "Compose",
                 Message = "Unrankable finishers",
                 Difficulties = _DIFFICULTIES,

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -141,8 +141,8 @@ namespace MVTaikoChecks.Checks.Compose
 
                     // check for unrankable finishers (problem)
                     if ((checkAndHandleIssues(diff, maximalGapBeats, beatmap, current)) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore) ||
-                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore && !isFirstNote) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter && !isFinalNote) ||
                         (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNote, beatmap, current) && !isFinalNote)) {
                         yield return new Issue(
                             GetTemplate(_PROBLEM),

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -8,12 +8,12 @@ using MapsetVerifierFramework.objects.metadata;
 using MVTaikoChecks.Utils;
 using System.Collections.Generic;
 using System.Linq;
+using static MVTaikoChecks.Global;
 using static MVTaikoChecks.Aliases.Difficulty;
 using static MVTaikoChecks.Aliases.Level;
 using static MVTaikoChecks.Aliases.Mode;
 
 namespace MVTaikoChecks.Checks.Compose
-#warning: TODO: improve error detection in oni and inner + implement finisher and preceding note same color detection
 {
     [Check]
     public class UnrankableFinisherCheck : BeatmapCheck
@@ -34,7 +34,7 @@ namespace MVTaikoChecks.Checks.Compose
         public override CheckMetadata GetMetadata() =>
             new BeatmapCheckMetadata()
             {
-                Author = "Hivie",
+                Author = "Hivie & Nostril",
                 Category = "Compose",
                 Message = "Unrankable finishers",
                 Difficulties = _DIFFICULTIES,
@@ -49,12 +49,7 @@ namespace MVTaikoChecks.Checks.Compose
                     {
                         "Reasoning",
                         @"
-                    Improper finisher usage can lead to significant gamplay issues."
-                    },
-                    {
-                        "Note",
-                        @"
-                    This check works well with Kantan, Futsuu, and Muzukashii difficulties. It's inconsistent with Oni and doesn't really work with Inner Oni difficulties, this will be fixed later."
+                    Improper finisher usage can lead to significant gameplay issues."
                     }
                 }
             };
@@ -82,108 +77,120 @@ namespace MVTaikoChecks.Checks.Compose
 
         public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
         {
-            var circles = beatmap.hitObjects.Where(x => x is Circle).ToList();
+            var finishers = beatmap.hitObjects.Where(x => x is Circle && x.IsFinisher()).ToList();
 
-            // for each diff: var violatingGroup = new List<HitObject>();
-            // lambda is used, because bare "new List<HitObject>()" would set the same instance in each pair
-            var violatingGroup = new Dictionary<Beatmap.Difficulty, List<HitObject>>();
-            violatingGroup.AddRange(_DIFFICULTIES, () => new List<HitObject>());
-
-            for (int i = 0; i < circles.Count; i++)
+            // any finisher pattern spacing equal to or smaller than this gap is a problem
+            var maximalGapBeats = new Dictionary<Beatmap.Difficulty, double>()
             {
-                var current = circles[i];
-                var next = circles.SafeGetIndex(i + 1);
-                var previous = i == 0 ? null : circles.SafeGetIndex(i - 1);
+                { DIFF_KANTAN,  1.0/3 },
+                { DIFF_FUTSUU,  1.0/3 },
+                { DIFF_MUZU,    1.0/4 },
+                { DIFF_ONI,     1.0/6 }
+            };
 
-                var timing = beatmap.GetTimingLine<UninheritedLine>(current.time);
-                var normalizedMsPerBeat = timing.GetNormalizedMsPerBeat();
+            // any finisher pattern spacing equal to or smaller than this gap is a problem
+            var maximalGapBeatsWarning = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_KANTAN,  1.0/2 }
+            };
 
-                // for each diff: double minimalGap = ?;
-                var minimalGap = new Dictionary<Beatmap.Difficulty, double>()
+            // any finisher pattern spacing equal to or smaller than this gap without a color change before is a problem
+            var maximalGapBeatsRequiringColorChangeBefore = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_ONI,     1.0/4 }
+            };
+
+            // any finisher pattern spacing equal to or smaller than this gap without a color change after is a problem
+            var maximalGapBeatsRequiringColorChangeAfter = new Dictionary<Beatmap.Difficulty, double>() { };
+
+            // any finisher pattern spacing equal to or smaller than this gap without a color change before is a warning
+            var maximalGapBeatsRequiringColorChangeBeforeWarning = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_INNER,   1.0/3 },
+                { DIFF_HELL,   1.0/3 }
+            };
+
+            // any finisher pattern spacing equal to or smaller than this gap without a color change after is a warning
+            var maximalGapBeatsRequiringColorChangeAfterWarning = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_INNER,   1.0/3 },
+                { DIFF_HELL,   1.0/3 }
+            };
+
+            // any finisher pattern spacing equal to or smaller than this gap while not being at the end of the pattern is a problem
+            var maximalGapBeatsRequiringFinalNote = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_ONI,     1.0/4 }
+            };
+
+            // any finisher pattern spacing equal to or smaller than this gap while not being at the end of the pattern is a warning
+            var maximalGapBeatsRequiringFinalNoteWarning = new Dictionary<Beatmap.Difficulty, double>()
+            {
+                { DIFF_INNER,   1.0/3 },
+                { DIFF_HELL,   1.0/3 }
+            };
+
+            foreach (var diff in _DIFFICULTIES)
+            {
+                foreach (var current in finishers)
                 {
-                    { DIFF_KANTAN, normalizedMsPerBeat / 2 },
-                    { DIFF_FUTSUU, normalizedMsPerBeat / 3 },
-                    { DIFF_MUZU, normalizedMsPerBeat / 3 },
-                    { DIFF_ONI, normalizedMsPerBeat / 4 },
-                    { DIFF_INNER, normalizedMsPerBeat / 4 },
-                    { DIFF_HELL, normalizedMsPerBeat / 4 },
-                };
+                    var sameColorBefore = (current.Prev()?.IsDon() ?? null) == current.IsDon();
+                    var sameColorAfter = (current.Next()?.IsDon() ?? null) == current.IsDon();
+                    var isFirstNote = current.IsAtBeginningOfPattern();
+                    var isFinalNote = current.IsAtEndOfPattern();
 
-                var nextGap = (next?.time ?? double.MaxValue) - current.time;
-                var previousGap =
-                    i == 0
-                        ? normalizedMsPerBeat
-                        : current.time - (previous?.time ?? double.MaxValue);
+                    // check for unrankable finishers (problem)
+                    if ((checkAndHandleIssues(diff, maximalGapBeats, beatmap, current)) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBefore, beatmap, current) && sameColorBefore) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfter, beatmap, current) && sameColorAfter) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNote, beatmap, current) && !isFinalNote)) {
+                        yield return new Issue(
+                            GetTemplate(_PROBLEM),
+                            beatmap,
+                            Timestamp.Get(current.time)
+                        ).ForDifficulties(diff);
+                        continue;
+                    }
 
-                // for each diff: bool violatingGroupEnded = false;
-                var violatingGroupEnded = new Dictionary<Beatmap.Difficulty, bool>();
-                violatingGroupEnded.AddRange(_DIFFICULTIES, false);
-
-                foreach (var diff in _DIFFICULTIES)
-                {
-                    CheckAndHandleIssues(
-                        diff,
-                        minimalGap,
-                        violatingGroup,
-                        violatingGroupEnded,
-                        current,
-                        nextGap,
-                        previousGap
-                    );
-
-                    if (violatingGroupEnded[diff])
-                    {
-                        if (
-                            diff == DIFF_KANTAN
-                            || diff == DIFF_FUTSUU
-                            || diff == DIFF_MUZU
-                            || (diff == DIFF_ONI && nextGap < minimalGap[DIFF_ONI])
-                        )
-                        {
-                            yield return new Issue(
-                                GetTemplate(_PROBLEM),
-                                beatmap,
-                                Timestamp.Get(violatingGroup[diff].ToArray())
-                            ).ForDifficulties(diff);
-
-                            violatingGroup[diff].Clear();
-                        }
-                        else if (diff == DIFF_INNER || diff == DIFF_HELL)
-                        {
-                            if (nextGap < minimalGap[diff])
-                            {
-                                yield return new Issue(
-                                    GetTemplate(_WARNING),
-                                    beatmap,
-                                    Timestamp.Get(violatingGroup[diff].ToArray())
-                                ).ForDifficulties(diff);
-
-                                violatingGroup[diff].Clear();
-                            }
-                        }
+                    // check for abnormal finishers (warning)
+                    if ((checkAndHandleIssues(diff, maximalGapBeatsWarning, beatmap, current)) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeBeforeWarning, beatmap, current) && sameColorBefore && !isFirstNote) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringColorChangeAfterWarning, beatmap, current) && sameColorAfter && !isFinalNote) ||
+                        (checkAndHandleIssues(diff, maximalGapBeatsRequiringFinalNoteWarning, beatmap, current) && !isFinalNote)) {
+                        yield return new Issue(
+                            GetTemplate(_WARNING),
+                            beatmap,
+                            Timestamp.Get(current.time)
+                        ).ForDifficulties(diff);
+                        continue;
                     }
                 }
             }
+            yield break;
         }
 
-        private static void CheckAndHandleIssues(
+        private bool checkAndHandleIssues(
             Beatmap.Difficulty diff,
-            Dictionary<Beatmap.Difficulty, double> minimalGap,
-            Dictionary<Beatmap.Difficulty, List<HitObject>> violatingGroup,
-            Dictionary<Beatmap.Difficulty, bool> violatingGroupEnded,
-            HitObject current,
-            double nextGap,
-            double previousGap
-        )
+            Dictionary<Beatmap.Difficulty, double> maximalGapBeats,
+            Beatmap beatmap,
+            HitObject current)
         {
-            if (current.HasHitSound(HitObject.HitSound.Finish))
+            // if check isn't relevant to this diff, don't check it
+            if (!maximalGapBeats.ContainsKey(diff))
             {
-                if (nextGap < minimalGap[diff] || previousGap < minimalGap[diff])
-                {
-                    violatingGroup[diff].Add(current);
-                    violatingGroupEnded[diff] = true;
-                }
+                return false;
             }
+
+            // convert maximal gap from # beats to milliseconds
+            var timing = beatmap.GetTimingLine<UninheritedLine>(current.time);
+            var maximalGapMs = maximalGapBeats[diff] * timing.msPerBeat;
+
+            if (current.GetPatternSpacingMs() <= maximalGapMs + MS_EPSILON)
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Checks/Compose/UnrankableFinisherCheck.cs
+++ b/Checks/Compose/UnrankableFinisherCheck.cs
@@ -181,7 +181,7 @@ namespace MVTaikoChecks.Checks.Compose
 
             // convert maximal gap from # beats to milliseconds
             var timing = beatmap.GetTimingLine<UninheritedLine>(current.time);
-            var maximalGapMs = maximalGapBeats[diff] * timing.msPerBeat;
+            var maximalGapMs = maximalGapBeats[diff] * timing.GetNormalizedMsPerBeat();
 
             if (current.GetPatternSpacingMs() <= maximalGapMs + MS_EPSILON)
             {

--- a/Utils/TaikoUtils.cs
+++ b/Utils/TaikoUtils.cs
@@ -1,0 +1,103 @@
+﻿using MapsetParser.objects;
+using MapsetParser.objects.hitobjects;
+using System;
+
+namespace MVTaikoChecks.Utils
+{
+    public static class TaikoUtils
+    {
+        public static bool IsDon(this HitObject hitObject)
+        {
+            return !hitObject.HasHitSound(HitObject.HitSound.Whistle) && !hitObject.HasHitSound(HitObject.HitSound.Clap);
+        }
+        public static bool IsFinisher(this HitObject hitObject)
+        {
+            return hitObject.HasHitSound(HitObject.HitSound.Finish);
+        }
+
+        public static bool IsAtBeginningOfPattern(this HitObject current)
+        {
+            var previous = current.Prev(true);
+            var next = current.Next(true);
+
+            // if there aren't circles immediately before this object, then this is the start of a pattern
+            if (previous == null || !(previous is Circle))
+            {
+                return true;
+            }
+
+            // if there are circles immediately before but not after this object, then this is not the start of a pattern
+            if (next == null || !(next is Circle))
+            {
+                return false;
+            }
+
+            var gapBeforeMs = current.time - previous.time;
+            var gapAfterMs = next.time - current.time;
+
+            // if there are circles both immediately before and after this object, then it's the start if the snap divisor after this note is lower than before it
+            return gapAfterMs < gapBeforeMs;
+        }
+
+        public static bool IsAtEndOfPattern(this HitObject current)
+        {
+            var previous = current.Prev(true);
+            var next = current.Next(true);
+
+            // if there aren't circles immediately after this object, then this is the end of a pattern
+            if (next == null || !(next is Circle))
+            {
+                return true;
+            }
+
+            // if there are circles immediately after but not before this object, then this is not the end of a pattern
+            if (previous == null || !(previous is Circle))
+            {
+                return false;
+            }
+
+            var gapBeforeMs = current.time - previous.time;
+            var gapAfterMs = next.time - current.time;
+
+            // if there are circles both immediately before and after this object, then it's the end if the snap divisor before this note is lower than after it
+            return gapBeforeMs < gapAfterMs;
+        }
+
+        public static bool IsInMiddleOfPattern(this HitObject current)
+        {
+            return !current.IsAtBeginningOfPattern() && !current.IsAtEndOfPattern();
+        }
+
+        public static bool IsNotInPattern(this HitObject current)
+        {
+            return current.IsAtBeginningOfPattern() && current.IsAtEndOfPattern();
+        }
+
+        public static double GetPatternSpacingMs(this HitObject current)
+        {
+            var previous = current.Prev(true);
+            var next = current.Next(true);
+
+            var gapBeforeMs = current.time - (previous?.time ?? 0);
+            var gapAfterMs = (next?.time ?? double.MaxValue) - current.time;
+
+            if (current.IsNotInPattern())
+            {
+                return 0;
+            }
+
+            if (current.IsAtBeginningOfPattern())
+            {
+                return gapAfterMs;
+            }
+
+            if (current.IsAtEndOfPattern())
+            {
+                return gapBeforeMs;
+            }
+
+            // if in middle of pattern, pattern spacing is based on which side has the smaller snap divisor
+            return Math.Min(gapBeforeMs, gapAfterMs);
+        }
+    }
+}

--- a/Utils/TaikoUtils.cs
+++ b/Utils/TaikoUtils.cs
@@ -8,11 +8,20 @@ namespace MVTaikoChecks.Utils
     {
         public static bool IsDon(this HitObject hitObject)
         {
+            if (!(hitObject is Circle))
+            {
+                return false;
+            }
             return !hitObject.HasHitSound(HitObject.HitSound.Whistle) && !hitObject.HasHitSound(HitObject.HitSound.Clap);
         }
         public static bool IsFinisher(this HitObject hitObject)
         {
             return hitObject.HasHitSound(HitObject.HitSound.Finish);
+        }
+
+        public static bool IsMono(this HitObject hitObject)
+        {
+            return (hitObject.Prev()?.IsDon() ?? null) == hitObject.IsDon();
         }
 
         public static bool IsAtBeginningOfPattern(this HitObject current)


### PR DESCRIPTION
## Summary
Resolves #5 

This PR fixes all the issues with the `UnrankableFinishersCheck`.

## Approach
Added a utility class (`TaikoUtils.cs`) which has a bunch of easy methods for checking a note's relationship to a pattern:
* `IsDon()`
* `IsFinisher()`
* `IsAtBeginningOfPattern()`
* `IsAtEndOfPattern()`
* `IsInMiddleOfPattern()` (unused currently)
* `IsNotInPattern()` (unused currently)
* `GetPatternSpacingMs()`

These methods are implemented by following this logic:
1. Look to the previous and next adjacent notes
2. Get the spacing between previous and adjacent
3. Lower spacing side = part of the same pattern (so beginning or end)
4. Same spacing = middle of pattern

For the actual check, I've added several dictionaries to define the first snap divisor that counts as a violation in various cases, with a Problem severity version and a Warning severity version:
* `maximalGapBeats` : Triggered if the pattern is <= this snap divisor regardless of any other conditions
* `maximalGapBeatsRequiringColorChangeBefore` : Triggered if note doesn't have a color change before it and isn't the first note, and the pattern is <= this snap divisor
* `maximalGapBeatsRequiringColorChangeAfter` : Triggered if note doesn't have a color change in the note after it and isn't the last note, and the pattern is <= this snap divisor
* `maximalGapBeatsRequiringFinalNote` : Triggered if note is the final note in the pattern, and the pattern is <= this snap divisor

## Testing
* Seems to work from everything I've tested. No known issues atm but feel free to test
