### PR TITLE
Fix rest moment BPM scaling

### DIFF
--- a/Checks/Compose/RestMomentCheck.cs
+++ b/Checks/Compose/RestMomentCheck.cs
@@ -204,7 +204,7 @@ namespace MVTaikoChecks.Checks.Compose
                         isWithinContinuousMapping = false;
                         var continuouslyMappedDurationMs = current.GetEndTime() - currentContinuousSectionStartTimeMs;
 
-                        double beatsWithoutBreaks = Math.Floor((continuouslyMappedDurationMs + MS_EPSILON) / normalizedMsPerBeat);
+                        double beatsWithoutBreaks = Math.Floor((continuouslyMappedDurationMs + MS_EPSILON) / timing.msPerBeat);
 
                         if (beatsWithoutBreaks > 0 && _DEBUG_SEE_ALL_CONTINUOUS_MAPPING)
                         {


### PR DESCRIPTION
Resolves #12 

## Issue
Let's take the hypothetical case of looking at a 120bpm Muzukashii beatmap.

Currently, we are doing the following scaling, using a 1.5x BPM scaling factor:
1. We're permitting `1/1` as a sufficent break (because `3/2` * 1.5x = `1/1`)
2. We're saying we need breaks every `32/3` (because `16/1` * 1.5x = `32/3`, about `11/1`) of continuous mapping

However we DO NOT want to be doing # 2, since we are already applying # 1 and applying # 2 would make break structure not align well with common song structures (1 bar = 4 measures = `16/1`, which our RC is based around).

## Fix
Only apply # 1 but not # 2