### PR TITLE
Add check for unsnapped last note hiding bar line

### DIFF
--- a/Checks/Compose/LastNoteHidingBarlineCheck.cs
+++ b/Checks/Compose/LastNoteHidingBarlineCheck.cs
@@ -34,12 +34,12 @@ namespace MVTaikoChecks.Checks.Compose
                     {
                         "Purpose",
                         @"
-                    Check that the last object in the beatmap is not 1ms earlier than a barline."
+                    Check if the last object in the beatmap is not 1ms earlier than a barline."
                     },
                     {
                         "Reasoning",
                         @"
-                    This can cause the last barline in the map to not be rendered."
+                    This causes the last barline in the map to not be rendered."
                     }
                 }
             };
@@ -52,18 +52,18 @@ namespace MVTaikoChecks.Checks.Compose
 
                     new IssueTemplate(
                         LEVEL_MINOR,
-                        "{0} Last spinner or slider in the map is hiding its barline, due to being unsnapped 1ms early",
+                        "{0} Last spinner/slider end in the map is hiding its barline, due to being unsnapped 1ms early",
                         "timestamp - "
-                    ).WithCause("The spinner or slider is unsnapped 1ms early.")
+                    ).WithCause("The spinner/slider end is unsnapped 1ms early.")
                 },
                 {
                     _PROBLEM,
 
                     new IssueTemplate(
                         LEVEL_PROBLEM,
-                        "{0} Last circle in the map is hiding its barline, due to being unsnapped 1ms early",
+                        "{0} Last note in the map is hiding its barline, due to being unsnapped 1ms early",
                         "timestamp - "
-                    ).WithCause("The circle is unsnapped 1ms early.")
+                    ).WithCause("The note is unsnapped 1ms early.")
                 }
             };
 

--- a/Checks/Compose/LastNoteHidingBarlineCheck.cs
+++ b/Checks/Compose/LastNoteHidingBarlineCheck.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+using MapsetParser.objects;
+using MapsetParser.objects.hitobjects;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using MVTaikoChecks.Utils;
+
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Compose
+{
+    [Check]
+    public class LastNoteHidingBarlineCheck : BeatmapCheck
+    {
+        private const string _MINOR = nameof(_MINOR);
+        private const string _PROBLEM = nameof(_PROBLEM);
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "Nostril",
+                Category = "Compose",
+                Message = "Unsnapped last note hiding barline",
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Check that the last object in the beatmap is not 1ms earlier than a barline."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    This can cause the last barline in the map to not be rendered."
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new Dictionary<string, IssueTemplate>()
+            {
+                {
+                    _MINOR,
+
+                    new IssueTemplate(
+                        LEVEL_MINOR,
+                        "{0} Last spinner or slider in the map is hiding its barline, due to being unsnapped 1ms early",
+                        "timestamp - "
+                    ).WithCause("The spinner or slider is unsnapped 1ms early.")
+                },
+                {
+                    _PROBLEM,
+
+                    new IssueTemplate(
+                        LEVEL_PROBLEM,
+                        "{0} Last circle in the map is hiding its barline, due to being unsnapped 1ms early",
+                        "timestamp - "
+                    ).WithCause("The circle is unsnapped 1ms early.")
+                }
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            var lastObject = beatmap.hitObjects.Last();
+
+            if (lastObject == null)
+            {
+                yield break;
+            }
+
+            var unsnapFromLastBarline = lastObject.GetTailOffsetFromNextBarlineMs();
+
+            if (unsnapFromLastBarline > -2.0 && unsnapFromLastBarline <= -1.0)
+            {
+                if (lastObject is Circle)
+                {
+                    yield return new Issue(
+                        GetTemplate(_PROBLEM),
+                        beatmap,
+                        Timestamp.Get(lastObject.GetEndTime())
+                    );
+                }
+                else
+                {
+                    yield return new Issue(
+                        GetTemplate(_MINOR),
+                        beatmap,
+                        Timestamp.Get(lastObject.GetEndTime())
+                    );
+                }
+            }
+        }
+    }
+}

--- a/Checks/Compose/LastNoteHidingBarlineCheck.cs
+++ b/Checks/Compose/LastNoteHidingBarlineCheck.cs
@@ -69,12 +69,12 @@ namespace MVTaikoChecks.Checks.Compose
 
         public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
         {
-            var lastObject = beatmap.hitObjects.Last();
-
-            if (lastObject == null)
+            if (beatmap.hitObjects.Count == 0)
             {
                 yield break;
             }
+
+            var lastObject = beatmap.hitObjects.Last();
 
             var unsnapFromLastBarline = lastObject.GetTailOffsetFromNextBarlineMs();
 

--- a/Utils/GeneralUtils.cs
+++ b/Utils/GeneralUtils.cs
@@ -30,5 +30,15 @@ namespace MVTaikoChecks.Utils
 
         public static T SafeGetIndex<T>(this List<T> collection, int index)
             => index < collection.Count ? collection[index] : default;
+
+        public static double TakeLowerAbsValue(double first, double second)
+        {
+            return Math.Abs(first) < Math.Abs(second) ? first : second;
+        }
+
+        public static double TakeHigherAbsValue(double first, double second)
+        {
+            return Math.Abs(first) > Math.Abs(second) ? first : second;
+        }
     }
 }


### PR DESCRIPTION
Resolves #11 

## Summary
This adds a check to see if the last note is unsnapped `1ms` early from its barline. This will result in that barline not being rendered.

For spinners and slider ends, this emits a minor warning. For hit circles, this emits a problem.

## Implementation
Added some helper methods to `TaikoUtils` to find the offset from the nearest barline.

Emit an error if `-2.0 < offset <= 1.0`, since these seem to be the conditions where the issue based on my testing. In osu editor this basically appears as just `-1ms` due to rounding.

## Testing
Tested using map from https://github.com/Hiviexd/MVTaikoChecks/issues/11#issuecomment-1741897398. Checked output of [`unsnapFromLastBarline`](https://github.com/hongaaronc/MVTaikoChecks/blob/11b61655c2a2d7664feecdfdf95bdd9a3a59450d/Checks/Compose/LastNoteHidingBarlineCheck.cs#L79) to see what the offset looks like to the exact decimal, and see how the map responds to it.