### PR TITLE
Add check for potential stuttering from 1st object offset

### DIFF
--- a/Checks/Timing/FirstNoteStutteringCheck.cs
+++ b/Checks/Timing/FirstNoteStutteringCheck.cs
@@ -51,9 +51,8 @@ namespace MVTaikoChecks.Checks.Timing
 
                     new IssueTemplate(
                         LEVEL_MINOR,
-                        "{0} first object's offset ({1}ms) is between {2}ms and {3}ms, which may cause stuttering at the start of the map. Ignore if there are no issues.",
+                        "{0} first object's offset is between {1}ms and {2}ms, which may cause stuttering at the start of the map. Ignore if there are no issues.",
                         "timestamp -",
-                        "offset",
                         "limit",
                         "recommended"
                     ).WithCause("The object's offset is between 150ms and 200ms.")
@@ -63,9 +62,8 @@ namespace MVTaikoChecks.Checks.Timing
 
                     new IssueTemplate(
                         LEVEL_WARNING,
-                        "{0} first object's offset ({1}ms) is below {2}ms, which may cause stuttering at the start of the map (recommended: {3}ms or more)",
+                        "{0} first object's offset is below {1}ms, which may cause stuttering at the start of the map (recommended: {2}ms or more)",
                         "timestamp -",
-                        "offset",
                         "limit",
                         "recommended"
                     ).WithCause("The object's offset is below the 150ms limit.")
@@ -89,7 +87,6 @@ namespace MVTaikoChecks.Checks.Timing
                     GetTemplate(_WARNING),
                     beatmap,
                     Timestamp.Get(firstObject.time),
-                    firstObject.time,
                     limit,
                     recommended
                 );
@@ -100,7 +97,6 @@ namespace MVTaikoChecks.Checks.Timing
                     GetTemplate(_MINOR),
                     beatmap,
                     Timestamp.Get(firstObject.time),
-                    firstObject.time,
                     limit,
                     recommended
                 );

--- a/Checks/Timing/FirstNoteStutteringCheck.cs
+++ b/Checks/Timing/FirstNoteStutteringCheck.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using MapsetParser.objects;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Timing
+{
+    [Check]
+    public class FirstNoteStuttering : BeatmapCheck
+    {
+        private const string _MINOR = nameof(_MINOR);
+        private const string _WARNING = nameof(_WARNING);
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "Hivie",
+                Category = "Timing",
+                Message = "Potential stuttering at the start of the map",
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Check if the first object's offset may cause stuttering at the start of the map."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    If the first object's offset is very early (below 150ms), it may cause stuttering at the start of the map.
+                    To fix this, extend the map's audio by at least 200ms.
+                        "
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new Dictionary<string, IssueTemplate>()
+            {
+                {
+                    _MINOR,
+
+                    new IssueTemplate(
+                        LEVEL_MINOR,
+                        "{0} first object's offset ({1}ms) is between {2}ms and {3}ms, which may cause stuttering at the start of the map. Ignore if there are no issues.",
+                        "timestamp -",
+                        "offset",
+                        "limit",
+                        "recommended"
+                    ).WithCause("The object's offset is between 150ms and 200ms.")
+                },
+                {
+                    _WARNING,
+
+                    new IssueTemplate(
+                        LEVEL_WARNING,
+                        "{0} first object's offset ({1}ms) is below {2}ms, which may cause stuttering at the start of the map (recommended: {3}ms or more)",
+                        "timestamp -",
+                        "offset",
+                        "limit",
+                        "recommended"
+                    ).WithCause("The object's offset is below the 150ms limit.")
+                }
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            if (beatmap.hitObjects.Count == 0)
+            {
+                yield break;
+            }
+
+            var firstObject = beatmap.hitObjects.First();
+            int limit = 150;
+            int recommended = 200;
+
+            if (firstObject.time < 150)
+            {
+                yield return new Issue(
+                    GetTemplate(_WARNING),
+                    beatmap,
+                    Timestamp.Get(firstObject.time),
+                    firstObject.time,
+                    limit,
+                    recommended
+                );
+            }
+            else if (firstObject.time < 200)
+            {
+                yield return new Issue(
+                    GetTemplate(_MINOR),
+                    beatmap,
+                    Timestamp.Get(firstObject.time),
+                    firstObject.time,
+                    limit,
+                    recommended
+                );
+            }
+        }
+    }
+}

--- a/Checks/Timing/LastNoteHidingBarlineCheck.cs
+++ b/Checks/Timing/LastNoteHidingBarlineCheck.cs
@@ -14,7 +14,7 @@ using MVTaikoChecks.Utils;
 using static MVTaikoChecks.Aliases.Mode;
 using static MVTaikoChecks.Aliases.Level;
 
-namespace MVTaikoChecks.Checks.Compose
+namespace MVTaikoChecks.Checks.Timing
 {
     [Check]
     public class LastNoteHidingBarlineCheck : BeatmapCheck
@@ -26,7 +26,7 @@ namespace MVTaikoChecks.Checks.Compose
             new BeatmapCheckMetadata()
             {
                 Author = "Nostril",
-                Category = "Compose",
+                Category = "Timing",
                 Message = "Unsnapped last note hiding barline",
                 Modes = new Beatmap.Mode[] { MODE_TAIKO },
                 Documentation = new Dictionary<string, string>()


### PR DESCRIPTION
basically if the offset of the first note is really early, the game will stutter upon hitting the first note which is annoying.

after testing, i found that 150ms is around the sweet spot for when this no longer happens, but i still want to suggest 200ms as the minimum because it's a much safer alternative

would like more opinions on the necessity of the minor check here, and if i can improve my wording on this one