### PR TITLE
Add check for pattern length

### DIFF
--- a/Checks/Compose/PatternLengthCheck.cs
+++ b/Checks/Compose/PatternLengthCheck.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MapsetParser.objects;
+using MapsetParser.objects.hitobjects;
+using MapsetParser.objects.timinglines;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using MVTaikoChecks.Utils;
+
+using static MVTaikoChecks.Global;
+using static MVTaikoChecks.Aliases.Difficulty;
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Compose
+{
+    [Check]
+    public class PatternLengthCheck : BeatmapSetCheck
+    {
+        private const string _WARNING = nameof(_WARNING);
+        private const bool _DEBUG_SEE_ALL_PATTERN_LENGTHS = false;
+
+        private readonly Beatmap.Difficulty[] _DIFFICULTIES = new Beatmap.Difficulty[]
+        {
+            DIFF_KANTAN,
+            DIFF_FUTSUU,
+            DIFF_MUZU,
+            DIFF_ONI
+        };
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "SN707",
+                Category = "Compose",
+                Message = "Pattern Lengths",
+                Difficulties = _DIFFICULTIES,
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Preventing small snaps from being too long based on each difficulty's Ranking Criteria."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    Certain snaps if going on for too long are too straining for certain difficulties."
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() => new Dictionary<string, IssueTemplate>()
+        {
+
+            {
+                _WARNING,
+                new IssueTemplate(LEVEL_WARNING,
+                    "{0} {1} {2} pattern is {3} notes long, ensure this makes sense",
+                    "start", "end", "snap", "number")
+                .WithCause("Chain length is surpassing the RC guideline")
+            }
+        };
+
+        public override IEnumerable<Issue> GetIssues(BeatmapSet beatmapSet)
+        {
+
+            // Difficulty, <snap size, snap count>
+            var shortSnapParams = new Dictionary<Beatmap.Difficulty, Dictionary<double, int>>()
+            {
+                { DIFF_KANTAN, new Dictionary<double, int>() {
+                    { 1.0 / 1, 7 },
+                    { 1.0 / 2, 2 }
+                }},
+                { DIFF_FUTSUU, new Dictionary< double, int>() {
+                    { 1.0 / 2, isBottomDiffKantan(beatmapSet) ? 7 : 5 }, // If no kantan, then recommended maximum 1/2 length for futsuu is 5 instead of 7
+                    { 1.0 / 3, 2 }
+                }},
+                { DIFF_MUZU, new Dictionary<double, int>() {
+                    { 1.0 / 4, 5 }, 
+                    { 1.0 / 6, 4 }, 
+                }},
+                { DIFF_ONI, new Dictionary<double, int>() {
+                    { 1.0 / 4, 9 }, 
+                    { 1.0 / 8, 2 }, 
+                }},
+            };
+
+            // Displays the fractions for output string
+            var outputDict = new Dictionary<double, String>()
+            {
+                { 1.0 / 1, "1/1" },
+                { 1.0 / 2, "1/2" },
+                { 1.0 / 3, "1/3" },
+                { 1.0 / 4, "1/4" },
+                { 1.0 / 6, "1/6" },
+                { 1.0 / 8, "1/8" }
+            };
+
+            foreach (var beatmap in beatmapSet.beatmaps)
+            {
+                var objects = beatmap.hitObjects.Where(x => x is Circle).ToList();
+
+                foreach (var diff in _DIFFICULTIES)
+                {
+                    foreach (var snapValues in shortSnapParams[diff])
+                    {
+                        var currentPatternStartTimeMs = objects.FirstOrDefault()?.time ?? 0;
+                        var currentPatternEndTimeMs = objects.FirstOrDefault()?.time ?? 0;
+
+                        // variables to identify length of pattern
+                        var patternStartIndex = 0;
+                        var foundStartOfPattern = false;
+                        var foundEndOfPattern = false;
+                        for (int i = 0; i < objects.Count; i++)
+                        {
+                            var current = objects.SafeGetIndex(i);
+                            var timing = beatmap.GetTimingLine<UninheritedLine>(current.time);
+                            var normalizedMsPerBeat = timing.GetNormalizedMsPerBeat();
+
+                            // convert minimal gap beats to milliseconds
+                            var snapMs = snapValues.Key * normalizedMsPerBeat;
+
+
+                            // check if this is end of pattern
+                            if (i + 1 < objects.Count && foundStartOfPattern)
+                            {
+                                var gapBeginObject = objects.SafeGetIndex(i);
+                                var gapEndObject = objects.SafeGetIndex(i + 1);
+
+                                // Check if gap is greater than the snap size
+                                var gap = gapEndObject.time - gapBeginObject.GetEndTime();
+                                if (gap - MS_EPSILON > snapMs)
+                                {
+                                    foundEndOfPattern = true;
+                                    currentPatternEndTimeMs = gapBeginObject.GetEndTime();
+                                }
+                            } else if (i == objects.Count - 1 && foundStartOfPattern)
+                            {
+                                // last note, so forced end of pattern
+                                foundEndOfPattern = true;
+                                currentPatternEndTimeMs = objects.SafeGetIndex(i).GetEndTime();
+                            }
+
+                            // check if this is start of pattern
+                            if (i + 1 < objects.Count && !foundStartOfPattern)
+                            {
+                                var gapBeginObject = objects.SafeGetIndex(i);
+                                var gapEndObject = objects.SafeGetIndex(i + 1);
+
+                                // Check if gap is smaller than or equal to the snap size
+                                var gap = gapEndObject.time - gapBeginObject.GetEndTime();
+                                if (gap - MS_EPSILON <= snapMs)
+                                {
+                                    foundStartOfPattern = true;
+                                    currentPatternStartTimeMs = gapBeginObject.GetEndTime();
+                                    patternStartIndex = i;
+                                }
+                            }
+
+                            // check if this is the last note of a pattern, and if so check if it's too long
+                            if (foundEndOfPattern && foundStartOfPattern)
+                            {
+                                foundEndOfPattern = false;
+                                foundStartOfPattern = false; // resume checking for start of pattern
+                                var durationOfPattern = i - patternStartIndex + 1;
+
+
+                                if (durationOfPattern > 1 && _DEBUG_SEE_ALL_PATTERN_LENGTHS)
+                                {
+                                    yield return new Issue(
+                                        GetTemplate(_WARNING),
+                                        beatmap,
+                                        Timestamp.Get(currentPatternStartTimeMs).Trim() + ">",
+                                        Timestamp.Get(currentPatternEndTimeMs).Trim() + ">",
+                                        outputDict[snapValues.Key] ?? "unknown snap",
+                                        durationOfPattern
+
+                                    ).ForDifficulties(diff);
+                                }
+                                else if (durationOfPattern > snapValues.Value)
+                                {
+                                    yield return new Issue(
+                                        GetTemplate(_WARNING),
+                                        beatmap,
+                                        Timestamp.Get(currentPatternStartTimeMs).Trim() + ">",
+                                        Timestamp.Get(currentPatternEndTimeMs).Trim() + ">",
+                                        outputDict[snapValues.Key] ?? "unknown snap",
+                                        durationOfPattern
+                                    ).ForDifficulties(diff);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Checks if bottom diff is kantan
+        private Boolean isBottomDiffKantan(BeatmapSet beatmapSet)
+        {
+            foreach (var beatmap in beatmapSet.beatmaps)
+            {
+                if (beatmap.GetDifficulty(true) == DIFF_KANTAN)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}
+

--- a/Checks/Compose/PatternLengthCheck.cs
+++ b/Checks/Compose/PatternLengthCheck.cs
@@ -64,7 +64,7 @@ namespace MVTaikoChecks.Checks.Compose
                 _MINOR,
 
                 new IssueTemplate(LEVEL_MINOR,
-                    "{0} {1} {2} pattern is {3} notes long, ensure this makes sense",
+                    "{0} {1} {2} pattern is {3} notes long.",
                     "start", "end", "snap", "number")
                 .WithCause("Pattern length is equal to the RC guideline")
             },
@@ -73,9 +73,9 @@ namespace MVTaikoChecks.Checks.Compose
             {
                 _WARNING,
                 new IssueTemplate(LEVEL_WARNING,
-                    "{0} {1} {2} pattern is {3} notes long, ensure this makes sense",
+                    "{0} {1} {2} pattern is {3} notes long, ensure this makes sense.",
                     "start", "end", "snap", "number")
-                .WithCause("Pattern length is surpassing the RC guideline")
+                .WithCause("Pattern length is surpassing the RC guideline.")
             }
         };
 
@@ -190,7 +190,7 @@ namespace MVTaikoChecks.Checks.Compose
                                         GetTemplate(_WARNING),
                                         beatmap,
                                         Timestamp.Get(currentPatternStartTimeMs).Trim() + ">",
-                                        Timestamp.Get(currentPatternEndTimeMs).Trim() + ">",
+                                        Timestamp.Get(currentPatternEndTimeMs).Trim() +,
                                         outputDict[snapValues.Key] ?? "unknown snap",
                                         durationOfPattern
 
@@ -202,7 +202,7 @@ namespace MVTaikoChecks.Checks.Compose
                                         GetTemplate(_WARNING),
                                         beatmap,
                                         Timestamp.Get(currentPatternStartTimeMs).Trim() + ">",
-                                        Timestamp.Get(currentPatternEndTimeMs).Trim() + ">",
+                                        Timestamp.Get(currentPatternEndTimeMs).Trim(),
                                         outputDict[snapValues.Key] ?? "unknown snap",
                                         durationOfPattern
                                     ).ForDifficulties(diff);
@@ -212,7 +212,7 @@ namespace MVTaikoChecks.Checks.Compose
                                         GetTemplate(_MINOR),
                                         beatmap,
                                         Timestamp.Get(currentPatternStartTimeMs).Trim() + ">",
-                                        Timestamp.Get(currentPatternEndTimeMs).Trim() + ">",
+                                        Timestamp.Get(currentPatternEndTimeMs).Trim(),
                                         outputDict[snapValues.Key] ?? "unknown snap",
                                         durationOfPattern
                                     ).ForDifficulties(diff);
@@ -223,7 +223,5 @@ namespace MVTaikoChecks.Checks.Compose
                 }
             }
         }
-        
     }
 }
-

--- a/Checks/Compose/PatternLengthCheck.cs
+++ b/Checks/Compose/PatternLengthCheck.cs
@@ -147,7 +147,7 @@ namespace MVTaikoChecks.Checks.Compose
                                 var gapEndObject = objects.SafeGetIndex(i + 1);
 
                                 // Check if gap is greater than the snap size
-                                var gap = gapEndObject.time - gapBeginObject.time;
+                                var gap = gapEndObject.time - gapBeginObject.GetEndTime();
                                 if (gap - MS_EPSILON > snapMs)
                                 {
                                     foundEndOfPattern = true;
@@ -167,7 +167,7 @@ namespace MVTaikoChecks.Checks.Compose
                                 var gapEndObject = objects.SafeGetIndex(i + 1);
 
                                 // Check if gap is smaller than or equal to the snap size
-                                var gap = gapEndObject.time - gapBeginObject.time;
+                                var gap = gapEndObject.time - gapBeginObject.GetEndTime();
                                 if (gap - MS_EPSILON <= snapMs)
                                 {
                                     foundStartOfPattern = true;

--- a/Utils/TaikoUtils.cs
+++ b/Utils/TaikoUtils.cs
@@ -161,5 +161,17 @@ namespace MVTaikoChecks.Utils
         {
             return TakeLowerAbsValue(current.GetTailOffsetFromPrevBarlineMs(), current.GetTailOffsetFromNextBarlineMs());
         }
+
+        public static bool IsBottomDiffKantan(this BeatmapSet beatmapSet)
+        {
+            foreach (var beatmap in beatmapSet.beatmaps)
+            {
+                if (beatmap.GetDifficulty(true) == Beatmap.Difficulty.Easy)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Resolves #19 

Summary:
----------

This adds a check to see if any patterns of certain snap divisors exceed certain lengths based on the Ranking Criteria.
So it currently emits a warning when it catches patterns longer than:
- Kantan:
  - `7`-plet `1/1`
  - `2`-plet `1/2`
- Futsuu:
  - `7`-plet `1/2`
    - `5`-plet `1/2` instead if there is no Kantan
  - `2`-plet `1/3`
- Muzu:
  - `5`-plet `1/4`
  - `4`-plet `1/6`
- Oni:
  - `9`-plet `1/4`
  - `4`-plet `1/6`
  - `2`-plet `1/8`

Tested using Hivie's phobberq map and a modified version of it where I removed the kantan, and added a couple of short snaps at the end.

Also Nostril why did you get me back into programming ;w;