### PR TITLE
Add BarlineUnaffectedBySvCheck and refactor Utils classes

### DIFF
--- a/Checks/Timing/BarlineUnaffectedBySvCheck.cs
+++ b/Checks/Timing/BarlineUnaffectedBySvCheck.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+
+using MapsetParser.objects;
+using MapsetParser.statics;
+
+using MapsetVerifierFramework.objects;
+using MapsetVerifierFramework.objects.attributes;
+using MapsetVerifierFramework.objects.metadata;
+
+using MVTaikoChecks.Utils;
+
+using static MVTaikoChecks.Aliases.Mode;
+using static MVTaikoChecks.Aliases.Level;
+
+namespace MVTaikoChecks.Checks.Compose
+{
+    [Check]
+    public class BarlineUnaffectedBySvCheck : BeatmapCheck
+    {
+        private const string _WARNING = nameof(_WARNING);
+
+        public override CheckMetadata GetMetadata() =>
+            new BeatmapCheckMetadata()
+            {
+                Author = "Nostril",
+                Category = "Timing",
+                Message = "Barline is unaffected by a line very close to it.",
+                Modes = new Beatmap.Mode[] { MODE_TAIKO },
+                Documentation = new Dictionary<string, string>()
+                {
+                    {
+                        "Purpose",
+                        @"
+                    Preventing unintentional barline slider velocities caused by timing lines being slightly unsnapped."
+                    },
+                    {
+                        "Reasoning",
+                        @"
+                    Barlines before a timing line (even if just by 1 ms or less), will not be affected by its slider velocity. With 1 ms unsnaps being common for due to rounding errors when copy pasting, this in turn becomes a common issue."
+                    }
+                }
+            };
+
+        public override Dictionary<string, IssueTemplate> GetTemplates() =>
+            new Dictionary<string, IssueTemplate>()
+            {
+                {
+                    _WARNING,
+
+                    new IssueTemplate(
+                        LEVEL_WARNING,
+                        "{0} Barline is snapped {1} ms before a line which would modify its slider velocity.",
+                        "timestamp - ",
+                        "unsnap"
+                    ).WithCause("The spinner/slider end is unsnapped 1ms early.")
+                }
+            };
+
+        public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
+        {
+            foreach (var svChange in beatmap.FindSvChanges())
+            {
+                var unsnapMs = TaikoUtils.GetOffsetFromNearestBarlineMs(beatmap, svChange.offset);
+                if (unsnapMs <= 1d && unsnapMs > 0d)
+                {
+                    yield return new Issue(
+                       GetTemplate(_WARNING),
+                       beatmap,
+                       Timestamp.Get(svChange.offset - unsnapMs),
+                       $"{unsnapMs:0.##}"
+                   );
+                }
+            }
+        }
+    }
+}

--- a/Checks/Timing/BarlineUnaffectedBySvCheck.cs
+++ b/Checks/Timing/BarlineUnaffectedBySvCheck.cs
@@ -17,6 +17,7 @@ namespace MVTaikoChecks.Checks.Compose
     [Check]
     public class BarlineUnaffectedBySvCheck : BeatmapCheck
     {
+        private const double THRESHOLD_MS = 5;
         private const string _WARNING = nameof(_WARNING);
 
         public override CheckMetadata GetMetadata() =>
@@ -61,7 +62,7 @@ namespace MVTaikoChecks.Checks.Compose
             foreach (var svChange in beatmap.FindSvChanges())
             {
                 var unsnapMs = TaikoUtils.GetOffsetFromNearestBarlineMs(beatmap, svChange.offset);
-                if (unsnapMs <= 1d && unsnapMs > 0d)
+                if (unsnapMs <= THRESHOLD_MS && unsnapMs > 0d)
                 {
                     yield return new Issue(
                        GetTemplate(_WARNING),

--- a/Checks/Timing/KiaiFlashCheck.cs
+++ b/Checks/Timing/KiaiFlashCheck.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
 
 using MapsetParser.objects;
@@ -64,7 +63,7 @@ namespace MVTaikoChecks.Checks.Timing
 
         public override IEnumerable<Issue> GetIssues(Beatmap beatmap)
         {
-            var kiaiToggles = beatmap.timingLines.FindKiaiToggles();
+            var kiaiToggles = beatmap.FindKiaiToggles();
 
             foreach (var toggle in kiaiToggles)
             {

--- a/Utils/OsuUtils.cs
+++ b/Utils/OsuUtils.cs
@@ -2,7 +2,6 @@
 using MapsetParser.objects.timinglines;
 using System;
 using System.IO;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace MVTaikoChecks.Utils
@@ -59,5 +58,27 @@ namespace MVTaikoChecks.Utils
             }
             return kiaiToggles;
         }
+
+        public static List<TimingLine> FindKiaiToggles(this Beatmap beatmap) => beatmap.timingLines.FindKiaiToggles();
+
+        public static List<TimingLine> FindSvChanges(this List<TimingLine> timingLines)
+        {
+            List<TimingLine> svChanges = new List<TimingLine>();
+            
+            for (int i=0; i<timingLines.Count-1; i++)
+            {
+                TimingLine firstLine = timingLines[i];
+                TimingLine secondLine = timingLines[i+1];
+
+                if (firstLine.svMult != secondLine.svMult && firstLine.offset != secondLine.offset)
+                {
+                    svChanges.Add(secondLine);
+                }
+            }
+
+            return svChanges;
+        }
+
+        public static List<TimingLine> FindSvChanges(this Beatmap beatmap) => beatmap.timingLines.FindSvChanges();
     }
 }

--- a/Utils/TaikoUtils.cs
+++ b/Utils/TaikoUtils.cs
@@ -112,55 +112,42 @@ namespace MVTaikoChecks.Utils
             return Math.Min(gapBeforeMs, gapAfterMs);
         }
 
-        public static double GetHeadOffsetFromPrevBarlineMs(this HitObject current)
+        public static double GetOffsetFromPrevBarlineMs(Beatmap beatmap, double time)
         {
-            var timing = current.beatmap.GetTimingLine<UninheritedLine>(current.time);
+            var timing = beatmap.GetTimingLine<UninheritedLine>(time);
             var barlineGap = timing.msPerBeat * timing.meter;
 
-            return (current.time - timing.offset) % barlineGap;
+            return (time - timing.offset) % barlineGap;
         }
 
-        public static double GetHeadOffsetFromNextBarlineMs(this HitObject current)
+        public static double GetOffsetFromNextBarlineMs(Beatmap beatmap, double time)
         {
-            var timing = current.beatmap.GetTimingLine<UninheritedLine>(current.time);
+            var timing = beatmap.GetTimingLine<UninheritedLine>(time);
             var barlineGap = timing.msPerBeat * timing.meter;
 
-            var offsetFromNextImplicitBarline = ((current.time - timing.offset) % barlineGap) - barlineGap;
-            var nextPotentialRedLine = current.beatmap.GetTimingLine<UninheritedLine>(current.time + offsetFromNextImplicitBarline);
-            var offsetFromNextPotentialRedline = current.time - nextPotentialRedLine.offset;
+            var offsetFromNextImplicitBarline = ((time - timing.offset) % barlineGap) - barlineGap;
+            var nextPotentialRedLine = beatmap.GetTimingLine<UninheritedLine>(time + offsetFromNextImplicitBarline);
+            var offsetFromNextPotentialRedline = time - nextPotentialRedLine.offset;
 
             return TakeLowerAbsValue(offsetFromNextImplicitBarline, offsetFromNextPotentialRedline);
         }
 
-        public static double GetHeadOffsetFromNearestBarlineMs(this HitObject current)
+        public static double GetOffsetFromNearestBarlineMs(Beatmap beatmap, double time)
         {
-            return TakeLowerAbsValue(current.GetHeadOffsetFromPrevBarlineMs(), current.GetHeadOffsetFromNextBarlineMs());
+            return TakeLowerAbsValue(GetOffsetFromPrevBarlineMs(beatmap, time), GetOffsetFromNextBarlineMs(beatmap, time));
         }
 
-        public static double GetTailOffsetFromPrevBarlineMs(this HitObject current)
-        {
-            var timing = current.beatmap.GetTimingLine<UninheritedLine>(current.GetEndTime());
-            var barlineGap = timing.msPerBeat * timing.meter;
+        public static double GetHeadOffsetFromPrevBarlineMs(this HitObject current) => GetOffsetFromPrevBarlineMs(current.beatmap, current.time);
 
-            return (current.GetEndTime() - timing.offset) % barlineGap;
-        }
+        public static double GetHeadOffsetFromNextBarlineMs(this HitObject current) => GetOffsetFromNextBarlineMs(current.beatmap, current.time);
 
-        public static double GetTailOffsetFromNextBarlineMs(this HitObject current)
-        {
-            var timing = current.beatmap.GetTimingLine<UninheritedLine>(current.GetEndTime());
-            var barlineGap = timing.msPerBeat * timing.meter;
+        public static double GetHeadOffsetFromNearestBarlineMs(this HitObject current) => GetOffsetFromNearestBarlineMs(current.beatmap, current.time);
 
-            var offsetFromNextImplicitBarline = ((current.GetEndTime() - timing.offset) % barlineGap) - barlineGap;
-            var nextPotentialRedLine = current.beatmap.GetTimingLine<UninheritedLine>(current.GetEndTime() + offsetFromNextImplicitBarline);
-            var offsetFromNextPotentialRedline = current.GetEndTime() - nextPotentialRedLine.offset;
+        public static double GetTailOffsetFromPrevBarlineMs(this HitObject current) => GetOffsetFromPrevBarlineMs(current.beatmap, current.GetEndTime());
 
-            return TakeLowerAbsValue(offsetFromNextImplicitBarline, offsetFromNextPotentialRedline);
-        }
+        public static double GetTailOffsetFromNextBarlineMs(this HitObject current) => GetOffsetFromNextBarlineMs(current.beatmap, current.GetEndTime());
 
-        public static double GetTailOffsetFromNearestBarlineMs(this HitObject current)
-        {
-            return TakeLowerAbsValue(current.GetTailOffsetFromPrevBarlineMs(), current.GetTailOffsetFromNextBarlineMs());
-        }
+        public static double GetTailOffsetFromNearestBarlineMs(this HitObject current) => GetOffsetFromNearestBarlineMs(current.beatmap, current.GetEndTime());
 
         public static bool IsBottomDiffKantan(this BeatmapSet beatmapSet)
         {


### PR DESCRIPTION
Resolves #22 

# Summary
This PR adds a `BarlineUnaffectedBySvCheck` which is similar to the Base MV's [`CheckBeforeLine`](https://github.com/Naxesss/MapsetChecks/blob/8ab99904032c965779148094061a98308471249e/Checks/AllModes/Timing/CheckBeforeLine.cs#L27), except it works on barlines. Template format / wording is mostly the same as the base MV one.

Threshold for detecting unsnaps is `5ms` - same as base MV's check.

I've also refactored the Utils classes to make them easier to work with.

# Testing
* Retested other checks that would be affected by the refactor: `LastNoteHidingBarlineCheck` and `KiaiFlashCheck`
* Tested in maps by adding SV changes `1ms` after the barline
* This check does *NOT* fix https://github.com/Hiviexd/MVTaikoChecks/issues/23.... this case is just so bizzarre and needs more investigation to fix