### PR TITLE
Add diff name groups to kiai consistency check

### DIFF
--- a/Checks/Timing/KiaiConsistencyCheck.cs
+++ b/Checks/Timing/KiaiConsistencyCheck.cs
@@ -75,13 +75,12 @@ namespace MVTaikoChecks.Checks.Timing
                 for (int i = 0; i < mapsetKiaiSetCount; i++)
                 {
                     yield return new Issue(
-                    GetTemplate(_MINOR),
-                    null,
-                    "Group " + (i + 1).ToString() + ": (" + string.Join(", ", diffNameStrings[i]) + ")"
+                        GetTemplate(_MINOR),
+                        null,
+                        "Group " + (i + 1).ToString() + ": (" + string.Join(", ", diffNameStrings[i]) + ")"
                     );
                 }
             }
         }
-
     }
 }

--- a/Checks/Timing/KiaiConsistencyCheck.cs
+++ b/Checks/Timing/KiaiConsistencyCheck.cs
@@ -11,6 +11,7 @@ using MVTaikoChecks.Utils;
 
 using static MVTaikoChecks.Aliases.Mode;
 using static MVTaikoChecks.Aliases.Level;
+using System;
 
 namespace MVTaikoChecks.Checks.Timing
 {
@@ -24,7 +25,7 @@ namespace MVTaikoChecks.Checks.Timing
             {
                 Author = "SN707, Nostril",
                 Category = "Compose",
-                Message = "Kiai consistency",
+                Message = "Kiai inconsistencies",
                 Modes = new Beatmap.Mode[] { MODE_TAIKO },
                 Documentation = new Dictionary<string, string>()
                 {
@@ -46,40 +47,41 @@ namespace MVTaikoChecks.Checks.Timing
             {
                 _MINOR,
                 new IssueTemplate(LEVEL_MINOR,
-                    "Kiai is inconsistent across difficulties.")
+                    "{0}",
+                    "List of Difficulty Names")
                 .WithCause("Kiai start and end times are not aligned across difficulties.")
             }
         };
 
         public override IEnumerable<Issue> GetIssues(BeatmapSet beatmapSet)
         {
-            // Store all kiai times in a 2D List
-            var mapsetKiais = new List<List<double>>();
+            // Store all kiai times in a Dictionary
+            var mapsetKiais = new Dictionary<string, List<string>>();
 
             foreach (var beatmap in beatmapSet.beatmaps)
             {
-                var beatmapKiais = beatmap.timingLines.FindKiaiToggles().Select(x => x.offset).ToList();
-                mapsetKiais.Add(beatmapKiais);
+                var beatmapKiais = string.Join(',', beatmap.timingLines.FindKiaiToggles().Select(x => x.offset));
+                mapsetKiais.TryAdd(beatmapKiais, new List<string>());
+                mapsetKiais[beatmapKiais].Add(beatmap.metadataSettings.version);
             }
 
-            List<double> firstDiffKiaiSet = mapsetKiais[0];
-
-            // Now we compare the first kiai times list to each of the remaining lists in the 2D array
-            for (int i = 1; i < mapsetKiais.Count; i++)
+            int mapsetKiaiSetCount = mapsetKiais.Count;
+            if (mapsetKiaiSetCount > 1)
             {
-                List<double> currentDiffKiaiSet = mapsetKiais[i];
-                var intersectKiaiSet = firstDiffKiaiSet.Intersect(currentDiffKiaiSet).ToList();
-                if (firstDiffKiaiSet.Count != intersectKiaiSet.Count || currentDiffKiaiSet.Count != intersectKiaiSet.Count)
+                // At least 2 different 'sets' of kiais
+                // Emit each of them and exit
+                var groupStrings = new List<string>();
+                List<List<string>> diffNameStrings = mapsetKiais.Values.ToList();
+                for (int i = 0; i < mapsetKiaiSetCount; i++)
                 {
-                    // intersection, current diff, and lowest diff toggles are not equal, so kiai is inconsistent.
-                    // Emit minor issue + finish.
                     yield return new Issue(
-                        GetTemplate(_MINOR),
-                        null
+                    GetTemplate(_MINOR),
+                    null,
+                    "Group " + (i + 1).ToString() + ": (" + string.Join(", ", diffNameStrings[i]) + ")"
                     );
-                    break;
                 }
             }
         }
+
     }
 }


### PR DESCRIPTION
Summary
----------
This modifies KiaiConsistencyCheck.cs so that instead of only emitting "Kiais are inconsistent across difficulties", it now also emits each 'group' where all difficulties within the group have the same kiai.

An example of a resulting output:
![765](https://github.com/Hiviexd/MVTaikoChecks/assets/38000093/6a55a19f-9a73-4478-8681-0ccfab24c091)

(In this example, the bottom 3 diffs have the same kiais and the first two have different kiais each)

Me and Nostril thought this was intuitive enough, but maybe it could be modified further?