### PR TITLE
Change messaging format in BgOffsetConsistencyCheck to match KiaiConsistencyCheck

### DIFF
--- a/Checks/Design/BgOffsetConsistencyCheck.cs
+++ b/Checks/Design/BgOffsetConsistencyCheck.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Numerics;
-using System.Text;
 
 using MapsetParser.objects;
 
@@ -22,7 +21,7 @@ namespace MVTaikoChecks.Checks.Timing
             {
                 Author = "Nostril",
                 Category = "Design",
-                Message = "Background offset inconsistency",
+                Message = "Background offset inconsistencies",
                 Documentation = new Dictionary<string, string>()
                 {
                     {
@@ -43,10 +42,10 @@ namespace MVTaikoChecks.Checks.Timing
             {
                 _MINOR,
                 new IssueTemplate(LEVEL_MINOR,
-                    "\"{0}\" has {1} unique offsets: {2}",
-                    "filename",
-                    "# found",
-                    "enumerated list")
+                    "\"{0}\" {1}: ({2})",
+                    "Filename",
+                    "Offset Coordinates",
+                    "List of Difficulties")
                 .WithCause("Background offset is inconsistent across difficulties. Make sure this is intentional.")
             }
         };
@@ -78,35 +77,19 @@ namespace MVTaikoChecks.Checks.Timing
                     continue;
                 }
 
-                var outputString = convertOffsetsToString(offsets);
-
-                yield return new Issue(
-                    GetTemplate(_MINOR),
-                    null,
-                    fileName,
-                    offsets.Count,
-                    outputString
-                );
+                foreach (var offset in offsets)
+                {
+                    var offsetCoords = offset.Key;
+                    var diffNames = string.Join(", ", offset.Value);
+                    yield return new Issue(
+                        GetTemplate(_MINOR),
+                        null,
+                        fileName,
+                        offsetCoords,
+                        diffNames
+                    );
+                }
             }
-        }
-
-        private string convertOffsetsToString(Dictionary<Vector2?, HashSet<string>> offsets)
-        {
-            if (offsets == null)
-            {
-                return null;
-            }
-
-            StringBuilder sb = new StringBuilder();
-            foreach (var offset in offsets) {
-                sb.Append(offset.Key);
-                sb.Append(" (");
-                sb.Append(string.Join(", ", offset.Value));
-                sb.Append("), ");
-            }
-            sb.Remove(sb.Length - 2, 2);    // Remove last trailing comma + space
-
-            return sb.ToString();
         }
     }
 }

--- a/Checks/Timing/KiaiConsistencyCheck.cs
+++ b/Checks/Timing/KiaiConsistencyCheck.cs
@@ -47,8 +47,9 @@ namespace MVTaikoChecks.Checks.Timing
             {
                 _MINOR,
                 new IssueTemplate(LEVEL_MINOR,
-                    "{0}",
-                    "List of Difficulty Names")
+                    "Group {0}: ({1})",
+                    "Kiai Group #",
+                    "List of Difficulties")
                 .WithCause("Kiai start and end times are not aligned across difficulties.")
             }
         };
@@ -77,7 +78,8 @@ namespace MVTaikoChecks.Checks.Timing
                     yield return new Issue(
                         GetTemplate(_MINOR),
                         null,
-                        "Group " + (i + 1).ToString() + ": (" + string.Join(", ", diffNameStrings[i]) + ")"
+                        (i + 1).ToString(),
+                        string.Join(", ", diffNameStrings[i])
                     );
                 }
             }


### PR DESCRIPTION
# Description

This just once again updates the way `BgOffsetConsistencyCheck` formats its messaging,  so that each set of offset groups are under its own sub-issue.

Basically just matches how https://github.com/Hiviexd/MVTaikoChecks/pull/26 did it since I like that a lot - nice and clean.

Also did a slight refactor for `KiaiConsistencyCheck` which doesn't change anything besides how it looks on the documentation screen. Just a bit more clear.

# Screenshots
### Showing the BgOffsetConsistencyCheck changes:

How it looks with 3 diffs each with their own offset:
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/47e73199-190c-4d9c-a579-b8e44920a742)

How it looks with 2 diffs with one offset, and 1 diff with another:
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/9a50536a-7182-4348-a93d-88db45a6ce8a)

### Showing `KiaiConsistencyCheck` refactor:

Still looks the same as before in the Checks screen:
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/a51c4361-5eeb-4db7-a1f9-8dc4be39c971)

Updated documentation screen:
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/e51fe222-7284-4126-8bfa-96a4291535b7)