### PR TITLE
Add warnings for<1ms barline issues

### DIFF
--- a/Checks/Timing/DoubleBarlineCheck.cs
+++ b/Checks/Timing/DoubleBarlineCheck.cs
@@ -119,7 +119,7 @@ namespace MVTaikoChecks.Checks.Timing
                 }
                 else if (rest - threshold <= 0 && rest > 0)
                 {
-                    if (rest >= 0.5 && rest < barlineGap/2)
+                    if (rest >= 0.5)
                     {
                         yield return new Issue(
                             GetTemplate(_PROBLEM),

--- a/Global.cs
+++ b/Global.cs
@@ -3,5 +3,6 @@
     public class Global
     {
         public const double MS_EPSILON = 2d;
+        public const double ROUNDING_ERROR_MARGIN = 0.000000001;
     }
 }


### PR DESCRIPTION
Closes #23, #24, #28 

## Description
In extremely rare cases, barline issues can happen when the notes are perfectly snapped in editor. However, stable has some logic where due to rounding/lack of precision, there actually _technically_ exists a _very small_ unsnap, even though it appears as 0ms in the editor. For examples of these cases, see #23, #24, and #28 

Also strangely enough, these rounding errors ONLY exist on stable - they will not occur if the same map is played on Lazer.

This PR will display a warning when this is detected, and asks the user to doublecheck them manually.

I think this is quite important to add, since nowadays more than ever, modders and BNs are becoming more reliant on MV for checking barline issues, and there are still a few that slip through the cracks. This will finally catch those rare edge cases where MV missed them before, and should make it so MV is something we can fully trust in this regard.

## Testing
I tested these changes manually on the maps in #23, #24, and #28 . The checks work as expected, and don't seem to appear on other maps where they shouldn't from what I saw.

## Screenshots / Examples
0ms last barline hidden detection - [Map](https://nostril.s-ul.eu/4QKh2gLx) @ `04:28:703` any diff
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/d37f4252-95e0-47e5-8551-7587f9b3823d)

0ms Double barline detection 1 - [Map](https://nostril.s-ul.eu/5soIpAZo) @ `01:08:944` any diff
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/a5b4868c-5c00-48e9-8724-70cfefb23306)

0ms Double barline detection 2 - [Map](https://nostril.s-ul.eu/7IFWGigj) @ `02:06:856` any diff
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/860783d6-1183-40a4-9828-6539cdd6f83a)

0ms barline not being affected properly by nearby SV - [Map](https://nostril.s-ul.eu/c1NkBHaU) @ `03:12:368` top diff
![image](https://github.com/Hiviexd/MVTaikoChecks/assets/5133530/1af0e702-cb0c-4056-a56b-5713931df361)
